### PR TITLE
Develop accept multi type records

### DIFF
--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -10,7 +10,11 @@ RSpec::Matchers.define :have_dns do
         if option == :type
           record.class.name.split('::').last == value.to_s
         else
-          record.send(option).to_s == value.to_s
+          if value.is_a? String
+            record.send(option).to_s == value
+          else
+            record.send(option) == value
+          end
         end
       end
     end


### PR DESCRIPTION
I wanted to do NS record like this.

``` ruby
describe 'google.com' do
  it { should have_dns.with_type('NS').and_name('ns2.google.com') }
end
```

But I could not.

Not all Resolv resources have "type". When type is missing, it occurs errors.
I changed way to distinguish the type.

And except record with address can not be tested if no address record.
I think all record is need to be change to string.

Finally, I added options description. It might be too verbose..

---

PS. "require 'yaml'" is nessesary for YAML in my envirionment, so I added.
