### PR TITLE
Replace deprecated rspec methods with new ones

### DIFF
--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -42,7 +42,7 @@ RSpec::Matchers.define :have_dns do
     end
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     if !@exceptions.empty?
       "tried to look up #{actual} but got #{@exceptions.size} exception(s): #{@exceptions.join(", ")}"
     elsif @refuse_request
@@ -54,7 +54,7 @@ RSpec::Matchers.define :have_dns do
     end
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     if !@exceptions.empty?
       "got #{@exceptions.size} exception(s):\n#{@exceptions.join("\n")}"
     elsif @refuse_request


### PR DESCRIPTION
Hi!

Trying to use rspec-dns, I was faced with the following warning message. 

```
Deprecation Warnings:

`failure_message_for_should_not` is deprecated. Use `failure_message_when_negated` instead. ...

`failure_message_for_should` is deprecated. Use `failure_message` instead. ...

```

I've replaced the deprecated rspec methods with new ones.
(see: [Module: RSpec::Matchers::DSL::Macros::Deprecated](http://www.rdoc.info/github/rspec/rspec-expectations/RSpec/Matchers/DSL/Macros/Deprecated))
