### PR TITLE
Change old RSpec style to RSpec 3 style

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then, create a spec like this:
 require 'spec_helper'
 
 describe 'www.example.com' do
-  it { should have_dns.with_type('TXT').and_ttl(300).and_data('a=b') }
+  it { is_expected.to have_dns.with_type('TXT').and_ttl(300).and_data('a=b') }
 end
 ```
 
@@ -46,8 +46,8 @@ require 'spec_helper'
 
 describe 'DNS tests' do
   it 'passes some tests' do
-    'www.example.com'.should have_dns.with_type('TXT').and_ttl(300).and_data('a=b')
-    'www.example.com'.should have_dns.with_type('A').and_ttl(300).and_address('1.2.3.4')
+    expect('www.example.com').to have_dns.with_type('TXT').and_ttl(300).and_data('a=b')
+    expect('www.example.com').to have_dns.with_type('A').and_ttl(300).and_address('1.2.3.4')
   end
 end
 ```
@@ -64,15 +64,15 @@ Here's some usage examples:
 
 ```ruby
   it 'checks if recursion is disabled' do
-    'google.com'.should have_dns.refuse_request
+    expect('google.com').to have_dns.refuse_request
   end
 
   it 'checks if gslb subdomain is delegated to dynect' do
-    'gslb.example.com'.should have_dns.in_authority.with_type('NS').and_name(/dynect/).at_least(3)
+    expect('gslb.example.com').to have_dns.in_authority.with_type('NS').and_name(/dynect/).at_least(3)
   end
 
   it 'checks number of hosts in round robin' do
-    'example.com'.should have_dns.with_type('A').at_least(3)
+    expect('example.com').to have_dns.with_type('A').at_least(3)
   end
 ```
 
@@ -109,7 +109,7 @@ Depending on the type of record, the following attributes may be available:
 If you try checking an attribute on a record that is non-existent (like checking the `rmailbx` on an `A` record), you'll get an error like this:
 
 ```text
-Failure/Error: it { should have_dns.with_type('TXT').and_ftl(300).and_data('a=b') }
+Failure/Error: it { is_expected.to have_dns.with_type('TXT').and_ftl(300).and_data('a=b') }
   got 1 exception(s): undefined method `rmailbx' for #<Dnsruby::RR::IN::A:0x007f66a0339b00>
 ```
 

--- a/spec/rspec-dns/have_dns_spec.rb
+++ b/spec/rspec-dns/have_dns_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 def stub_records(strings)
   records = strings.map { |s| Dnsruby::RR.new_from_string(s) }
   resolver = Dnsruby::Resolver.new
-  Dnsruby::Resolver.stub(:new) do
+  allow(Dnsruby::Resolver).to receive(:new) do
     yield if block_given?
     resolver
   end
-  resolver.stub_chain(:query, :answer).and_return(records)
+  allow(resolver).to receive_message_chain(:query, :answer).and_return(records)
 end
 
 describe 'rspec-dns matchers' do
@@ -17,66 +17,66 @@ describe 'rspec-dns matchers' do
       it 'can evalutate an A record' do
         stub_records(['example.com 86400 A 192.168.100.100'])
 
-        'example.com'.should have_dns.with_type('A')
-        'example.com'.should_not have_dns.with_type('TXT')
-        'example.com'.should have_dns.with_type('A').and_address('192.168.100.100')
+        expect('example.com').to have_dns.with_type('A')
+        expect('example.com').to_not have_dns.with_type('TXT')
+        expect('example.com').to have_dns.with_type('A').and_address('192.168.100.100')
       end
 
       it 'can evalutate a AAAA record' do
         stub_records(['example.com 86400 AAAA 2001:0002:6c::430'])
 
-        'example.com'.should have_dns.with_type('AAAA')
-        'example.com'.should_not have_dns.with_type('A')
-        'example.com'.should have_dns.with_type('AAAA')
+        expect('example.com').to have_dns.with_type('AAAA')
+        expect('example.com').to_not have_dns.with_type('A')
+        expect('example.com').to have_dns.with_type('AAAA')
           .and_address('2001:2:6C::430')
       end
 
       it 'can evalutate a CNAME record' do
         stub_records(['www.example.com 300 IN CNAME example.com'])
 
-        'example.com'.should have_dns.with_type('CNAME')
-        'example.com'.should_not have_dns.with_type('AAAA')
-        'example.com'.should have_dns.with_type('CNAME').and_name('www.example.com')
+        expect('example.com').to have_dns.with_type('CNAME')
+        expect('example.com').to_not have_dns.with_type('AAAA')
+        expect('example.com').to have_dns.with_type('CNAME').and_name('www.example.com')
       end
 
       it 'can evalutate an MX record' do
         stub_records(['example.com. 7200 MX 40 mail.example.com.'])
 
-        'example.com'.should have_dns.with_type('MX')
-        'example.com'.should_not have_dns.with_type('CNAME')
-        'example.com'.should have_dns.with_type('MX').and_preference(40)
-        'example.com'.should have_dns.with_type('MX')
+        expect('example.com').to have_dns.with_type('MX')
+        expect('example.com').to_not have_dns.with_type('CNAME')
+        expect('example.com').to have_dns.with_type('MX').and_preference(40)
+        expect('example.com').to have_dns.with_type('MX')
           .and_preference(40).and_exchange('mail.example.com')
-        'example.com'.should_not have_dns.with_type('MX')
+        expect('example.com').to_not have_dns.with_type('MX')
           .and_preference(30).and_exchange('mail.example.com')
-        'example.com'.should_not have_dns.with_type('MX')
+        expect('example.com').to_not have_dns.with_type('MX')
           .and_preference(40).and_exchange('example.com')
       end
 
       it 'can evalutate an NS record' do
         stub_records(['sub.example.com. 300 IN NS ns.sub.example.com.'])
 
-        'example.com'.should have_dns.with_type('NS')
-        'example.com'.should_not have_dns.with_type('MX')
-        'example.com'.should have_dns.with_type('NS').and_domainname('ns.sub.example.com')
-        'example.com'.should_not have_dns.with_type('NS').and_domainname('sub.example.com')
+        expect('example.com').to have_dns.with_type('NS')
+        expect('example.com').to_not have_dns.with_type('MX')
+        expect('example.com').to have_dns.with_type('NS').and_domainname('ns.sub.example.com')
+        expect('example.com').to_not have_dns.with_type('NS').and_domainname('sub.example.com')
       end
 
       it 'can evalutate a PTR record' do
         stub_records(['ptrs.example.com. 300 IN PTR ptr.example.com.'])
 
-        '192.168.100.100'.should have_dns.with_type('PTR')
-        '192.168.100.100'.should_not have_dns.with_type('MX')
-        '192.168.100.100'.should have_dns.with_type('PTR').and_domainname('ptr.example.com')
-        '192.168.100.100'.should_not have_dns.with_type('PTR').and_domainname('ptrs.example.com')
+        expect('192.168.100.100').to have_dns.with_type('PTR')
+        expect('192.168.100.100').to_not have_dns.with_type('MX')
+        expect('192.168.100.100').to have_dns.with_type('PTR').and_domainname('ptr.example.com')
+        expect('192.168.100.100').to_not have_dns.with_type('PTR').and_domainname('ptrs.example.com')
       end
 
       it 'can evalutate an SOA record' do
         stub_records(['example.com 210 IN SOA ns.example.com a.example.com. 2014030712 60 25 3628800 900'])
 
-        'example.com'.should have_dns.with_type('SOA')
-        'example.com'.should_not have_dns.with_type('PTR')
-        'example.com'.should have_dns.with_type('SOA')
+        expect('example.com').to have_dns.with_type('SOA')
+        expect('example.com').to_not have_dns.with_type('PTR')
+        expect('example.com').to have_dns.with_type('SOA')
           .and_mname('ns.example.com')
           .and_rname('a.example.com')
           .and_serial('2014030712')
@@ -84,34 +84,34 @@ describe 'rspec-dns matchers' do
           .and_retry(25)
           .and_expire(3628800)
           .and_minimum(900)
-        'example.com'.should_not have_dns.with_type('SOA')
+        expect('example.com').to_not have_dns.with_type('SOA')
           .and_mname('nstest.example.com')
       end
 
       it 'can evalutate a TXT record' do
         stub_records(['example.com. 300 IN TXT "v=spf1 a:example.com ~all"'])
 
-        'example.com'.should have_dns.with_type('TXT')
-        'example.com'.should_not have_dns.with_type('SOA')
-        'example.com'.should have_dns.with_type('TXT').and_data('v=spf1 a:example.com ~all')
-        'example.com'.should_not have_dns.with_type('TXT').and_data('v=spf2 a:example.com ~all')
+        expect('example.com').to have_dns.with_type('TXT')
+        expect('example.com').to_not have_dns.with_type('SOA')
+        expect('example.com').to have_dns.with_type('TXT').and_data('v=spf1 a:example.com ~all')
+        expect('example.com').to_not have_dns.with_type('TXT').and_data('v=spf2 a:example.com ~all')
       end
     end
 
     context 'with changable connection timeout' do
-      it 'should timeout within 3 seconds in default' do
+      it 'is_expected.to timeout within 3 seconds in default' do
         stub_records(['example.com 86400 A 192.168.100.100']) do
           sleep 3
         end
-        'example.com'.should_not have_dns.with_type('A')
+        expect('example.com').to_not have_dns.with_type('A')
       end
 
-      it 'should not timeout within 3 seconds when timeout is 5' do
+      it 'is_expected.to not timeout within 3 seconds when timeout is 5' do
         RSpec.configuration.rspec_dns_connection_timeout = 5
         stub_records(['example.com 86400 A 192.168.100.100']) do
           sleep 3
         end
-        'example.com'.should have_dns.with_type('A')
+        expect('example.com').to have_dns.with_type('A')
       end
     end
   end


### PR DESCRIPTION
I have changed old RSpec style to RSpec 3 style.
- spec
  - Because I want to add a new chain method or something,  but RSpec indicates old style now, and it is annoying.
- README.md
  - Because if our test style changes, it should have the same style.
