### PR TITLE
Handle argument as IPAddr if possible

### DIFF
--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -17,7 +17,9 @@ RSpec::Matchers.define :have_dns do
       matched = _options.all? do |option, value|
         begin
           # To distinguish types because not all Resolv returns have type
-          if value.is_a? String
+          if ipaddr = (IPAddr.new(value) rescue nil) # IPAddr(v4/v6)?
+            ipaddr.include?(record.send(option).to_s)
+          elsif value.is_a? String
             record.send(option).to_s == value
           elsif value.is_a? Regexp
             record.send(option).to_s =~ value

--- a/spec/rspec-dns/have_dns_spec.rb
+++ b/spec/rspec-dns/have_dns_spec.rb
@@ -31,6 +31,16 @@ describe 'rspec-dns matchers' do
           .and_address('2001:DB8:6C::430')
       end
 
+      it 'can evalutate an A/AAAA record with IPAddr range' do
+        stub_records(['example.com 86400 A 192.0.2.4',
+                      'example.com 86400 AAAA 2001:DB8:6c::430'])
+
+        expect('example.com').to have_dns.with_type('A')
+          .and_address('192.0.2.0/24')
+        expect('example.com').to have_dns.with_type('AAAA')
+          .and_address('2001:DB8:6C::/64')
+      end
+
       it 'can evalutate a CNAME record' do
         stub_records(['www.example.com 300 IN CNAME example.com'])
 


### PR DESCRIPTION
Some providers have ranged IP addresses for their services.
For example, github.com has [192.30.252.0/22](https://help.github.com/articles/what-ip-addresses-does-github-use-that-i-should-whitelist/).

I want to write spec like that:

``` ruby
        expect('github.com').to have_dns.with_type('A')
          .and_address('192.30.252.0/22')
```
