### PR TITLE
Fix incorrect test with in_zone_file chain

### DIFF
--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -136,7 +136,7 @@ RSpec::Matchers.define :have_dns do
     if @zone_file
       @_records = Dnsruby::Message.new
       rrs = Dnsruby::ZoneReader.new(@zone_origin).process_file(@zone_file)
-      rrs.each { |rr| @_records.add_answer(rr) }
+      rrs.each { |rr| @_records.add_answer(rr) if @dns == rr.name.to_s  }
     end
 
     @_records ||= begin

--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -136,7 +136,13 @@ RSpec::Matchers.define :have_dns do
     if @zone_file
       @_records = Dnsruby::Message.new
       rrs = Dnsruby::ZoneReader.new(@zone_origin).process_file(@zone_file)
-      rrs.each { |rr| @_records.add_answer(rr) if @dns == rr.name.to_s  }
+      name = if (IPAddr.new(@dns) rescue nil) # Check if IPAddr(v4,v6)
+               IPAddr.new(@dns).reverse
+             else
+                @dns
+             end
+
+      rrs.each { |rr| @_records.add_answer(rr) if name == rr.name.to_s  }
     end
 
     @_records ||= begin

--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -133,16 +133,16 @@ RSpec::Matchers.define :have_dns do
   end
 
   def _records
+    @_name ||= if (IPAddr.new(@dns) rescue nil) # Check if IPAddr(v4,v6)
+                 IPAddr.new(@dns).reverse
+               else
+                 @dns
+               end
+
     if @zone_file
       @_records = Dnsruby::Message.new
       rrs = Dnsruby::ZoneReader.new(@zone_origin).process_file(@zone_file)
-      name = if (IPAddr.new(@dns) rescue nil) # Check if IPAddr(v4,v6)
-               IPAddr.new(@dns).reverse
-             else
-                @dns
-             end
-
-      rrs.each { |rr| @_records.add_answer(rr) if name == rr.name.to_s  }
+      rrs.each { |rr| @_records.add_answer(rr) if @_name == rr.name.to_s  }
     end
 
     @_records ||= begin
@@ -152,11 +152,7 @@ RSpec::Matchers.define :have_dns do
       Timeout::timeout(query_timeout + 0.2) do
         resolver =  Dnsruby::Resolver.new(config)
         resolver.query_timeout = query_timeout
-        if (IPAddr.new(@dns) rescue nil) # Check if IPAddr(v4,v6)
-          resolver.query(@dns, Dnsruby::Types.PTR)
-        else
-          resolver.query(@dns, Dnsruby::Types.ANY)
-        end
+        resolver.query(@_name, Dnsruby::Types.ANY)
       end
     rescue Exception => e
       if Dnsruby::NXDomain === e

--- a/spec/rspec-dns/0.2.0.192.rev.zone
+++ b/spec/rspec-dns/0.2.0.192.rev.zone
@@ -1,0 +1,11 @@
+$TTL 86400
+
+@ IN SOA  ns.example.com.  root.example.com. (
+          2015020102  ; Serial
+          3600        ; Refresh
+          900         ; Retry
+          604800      ; Expire
+          900         ; Minimum
+          )
+          IN NS        ns.example.com.
+4         IN PTR       www.example.com.

--- a/spec/rspec-dns/have_dns_spec.rb
+++ b/spec/rspec-dns/have_dns_spec.rb
@@ -140,6 +140,23 @@ describe 'rspec-dns matchers' do
           .and_address('2001:DB8:6C::430')
           .in_zone_file(file, origin)
       end
+      context 'in reverse' do
+        it 'can evalutate PTR records in zone file' do
+          file = 'spec/rspec-dns/0.2.0.192.rev.zone'
+          origin =  '2.0.192.in-addr.arpa.'
+
+          expect('4.2.0.192.in-addr.arpa').to have_dns.with_type('PTR')
+            .and_domainname('www.example.com')
+            .in_zone_file(file, origin)
+          expect('5.2.0.192.in-addr.arpa').not_to have_dns.with_type('PTR')
+            .and_domainname('www.example.com')
+            .in_zone_file(file, origin)
+          expect('192.0.2.4').to have_dns.with_type('PTR')
+            .and_domainname('www.example.com')
+            .in_zone_file(file, origin)
+        end
+      end
+
       it 'can evalutate records in zone file without origin' do
         file = 'spec/rspec-dns/example.zone'
 

--- a/spec/rspec-dns/have_dns_spec.rb
+++ b/spec/rspec-dns/have_dns_spec.rb
@@ -133,6 +133,9 @@ describe 'rspec-dns matchers' do
         expect('www.example.com').to have_dns.with_type('A')
           .and_address('192.0.2.4')
           .in_zone_file(file, origin)
+        expect('doubt.example.com').not_to have_dns.with_type('A')
+          .and_address('192.0.2.4')
+          .in_zone_file(file, origin)
         expect('www.example.com').to have_dns.with_type('AAAA')
           .and_address('2001:DB8:6C::430')
           .in_zone_file(file, origin)
@@ -143,6 +146,8 @@ describe 'rspec-dns matchers' do
         expect('').to have_dns.with_type('NS')
           .and_domainname('ns').in_zone_file(file)
         expect('www').to have_dns.with_type('A')
+          .and_address('192.0.2.4').in_zone_file(file)
+        expect('doubt').not_to have_dns.with_type('A')
           .and_address('192.0.2.4').in_zone_file(file)
       end
       it 'can evalutate records with dns servers if file is nil' do

--- a/spec/rspec-dns/have_dns_spec.rb
+++ b/spec/rspec-dns/have_dns_spec.rb
@@ -140,7 +140,7 @@ describe 'rspec-dns matchers' do
       it 'can evalutate records in zone file without origin' do
         file = 'spec/rspec-dns/example.zone'
 
-        expect('.').to have_dns.with_type('NS')
+        expect('').to have_dns.with_type('NS')
           .and_domainname('ns').in_zone_file(file)
         expect('www').to have_dns.with_type('A')
           .and_address('192.0.2.4').in_zone_file(file)


### PR DESCRIPTION
~~This is work in progress pull request.~~(Done 2015-01-31 22:25:55 UTC)

I found `in_zone_file` usecase has a bug, and `in_zone_file` chain cannot evaluate zone file correctly. Now, if we use `in_zone_file`, `have_dns` passes following example(doubt.example.com should be failed, but does not).

I'm doing fixing this bug.

zone_file(example.zone)
```
$TTL 86400

@ IN SOA  ns.example.com.  root.example.com. (
          2014122413  ; Serial
          3600        ; Refresh
          900         ; Retry
          604800      ; Expire
          900         ; Minimum
          )
          IN NS        ns
          IN MX   40   mail
          IN A         192.0.2.4
www       IN A         192.0.2.4
www       IN AAAA      2001:DB8:6C::430
```
spec
```ruby
    context 'with zone file' do
      it 'can evalutate records in zone file with origin' do
        file = 'spec/rspec-dns/example.zone'
        origin =  'example.com.'

        expect('www.example.com').to have_dns.with_type('A')
          .and_address('192.0.2.4')
          .in_zone_file(file, origin)
        expect('doubt.example.com').to have_dns.with_type('A')
          .and_address('192.0.2.4')
          .in_zone_file(file, origin)
      end
    end
```