### PR TITLE
Change resolver not to do caching

### DIFF
--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -152,6 +152,7 @@ RSpec::Matchers.define :have_dns do
       Timeout::timeout(query_timeout + 0.2) do
         resolver =  Dnsruby::Resolver.new(config)
         resolver.query_timeout = query_timeout
+        resolver.do_caching = false
         resolver.query(@_name, Dnsruby::Types.ANY)
       end
     rescue Exception => e


### PR DESCRIPTION
According to the issue "There's no way to test multiple nameservers" #22,
we have seen there is a problem related to caching. 

I have changed to resolver not to do caching.
It sometimes take time more. But rspec-dns is a test tool, so needs to test correctly.

Please check it.

CC/ @Paladin