### PR TITLE
Update bundler before travis builds and make travis faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
-script: rake travis
+cache: bundler
+sudo: false
+script: bundle exec rake travis
 before_install:
  - gem update bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 script: rake travis
+before_install:
+ - gem update bundler
 rvm:
 - 1.9.3
 - 2.2.0


### PR DESCRIPTION
We found CI on Travis-CI failed when bundle install because installed bundler has issue.
Ref: bundler/bundler#3558 https://travis-ci.org/spotify/rspec-dns/jobs/98399618#L142

----
Added at 2015-12-25 05:47:46 +0900

I have changed .travis.yml for faster build on Travis CI according to [Faster Builds with Container-Based Infrastructure and Docker](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/)