### PR TITLE
Use authoritative records without being explicit

### DIFF
--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -7,13 +7,10 @@ RSpec::Matchers.define :have_dns do
     @dns = dns
     @exceptions = []
 
-    if @authority || _records.authority.any?
-      @records = _records.authority
-    elsif @additional
-      @records = _records.additional
-    else
-      @records = _records.answer
-    end
+    @records = []
+    @records.concat(_records.authority) if @authority
+    @records.concat(_records.additional) if @additional
+    @records.concat(_records.answer) if @answer || (!@authority && !@additional)
 
     results = @records.find_all do |record|
       matched = _options.all? do |option, value|
@@ -74,10 +71,22 @@ RSpec::Matchers.define :have_dns do
 
   chain :in_authority do
     @authority = true
+    @answer = @additional = false
   end
 
   chain :in_additional do
     @additional = true
+    @authority = @answer = false
+  end
+
+  chain :in_answer do
+    @answer = true
+    @authority = @additional = false
+  end
+
+  chain :in_authority_or_answer do
+    @authority = @answer = true
+    @additional = false
   end
 
   chain :at_least do |actual|

--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -7,7 +7,7 @@ RSpec::Matchers.define :have_dns do
     @dns = dns
     @exceptions = []
 
-    if @authority
+    if @authority || _records.authority.any?
       @records = _records.authority
     elsif @additional
       @records = _records.additional

--- a/lib/rspec-dns/have_dns.rb
+++ b/lib/rspec-dns/have_dns.rb
@@ -154,6 +154,14 @@ RSpec::Matchers.define :have_dns do
                  @dns
                end
 
+    if _options[:type] == "CNAME"
+      begin
+        Dnsruby::Resolv.getaddresses(@_name)
+      rescue Dnsruby::NXDomain => e
+        @exceptions << "CNAME chain is not fully resolvable. This is potentially a dangling DNS record!"
+      end
+    end
+
     if @zone_file
       @_records = Dnsruby::Message.new
       rrs = Dnsruby::ZoneReader.new(@zone_origin).process_file(@zone_file)

--- a/spec/rspec-dns/have_dns_spec.rb
+++ b/spec/rspec-dns/have_dns_spec.rb
@@ -211,5 +211,21 @@ describe 'rspec-dns matchers' do
         expect('ns.sub.example.com').to have_dns.in_additional.with_type('A').and_address('192.0.2.5')
       end
     end
+    context 'with in_authority_or_answer chain' do
+      it 'can evalutate an NS record in authority' do
+        stub_records(['sub.example.com. 300 IN NS ns.sub.example.com.'], :authority)
+        stub_records([])
+
+        expect('sub.example.com').to have_dns.with_type('NS').in_authority_or_answer
+        expect('sub.example.com').to have_dns.with_type('NS').in_authority_or_answer.and_domainname('ns.sub.example.com')
+      end
+      it 'can evalutate an NS record in answer' do
+        stub_records(['sub.example.com. 300 IN NS ns.sub.example.com.'])
+        stub_records([], :authority)
+
+        expect('sub.example.com').to have_dns.with_type('NS').in_authority_or_answer
+        expect('sub.example.com').to have_dns.with_type('NS').in_authority_or_answer.and_domainname('ns.sub.example.com')
+      end
+    end
   end
 end

--- a/spec/rspec-dns/have_dns_spec.rb
+++ b/spec/rspec-dns/have_dns_spec.rb
@@ -226,6 +226,13 @@ describe 'rspec-dns matchers' do
         expect('sub.example.com').to have_dns.with_type('NS').in_authority_or_answer
         expect('sub.example.com').to have_dns.with_type('NS').in_authority_or_answer.and_domainname('ns.sub.example.com')
       end
+      it 'fails to evalutate an NS record in additional' do
+        stub_records(['sub.example.com. 300 IN NS ns.sub.example.com.'], :additional)
+        stub_records([], :authority)
+        stub_records([])
+
+        expect('sub.example.com').not_to have_dns.with_type('NS').in_authority_or_answer
+      end
     end
   end
 end


### PR DESCRIPTION
Whilst migrating some DNS services between providers, there is the need
to confirm the existence and conformity of (delegated) NS records.

Take the following zone configuration for two providers

- Provider 1 (Existing)

```
; <<>> DiG 9.8.3-P1 <<>> -t ns test.example.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44807
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 4, ADDITIONAL: 0

;; QUESTION SECTION:
;test.example.com.           IN      NS

;; ANSWER SECTION:
test.example.com.    77494   IN      NS      ns-1.domain.org.
test.example.com.    77494   IN      NS      ns-2.domain.co.uk.
test.example.com.    77494   IN      NS      ns-3.domain.com.
test.example.com.    77494   IN      NS      ns-4.domain.net.

```

- Provider 2 (Proposed)

```
; <<>> DiG 9.8.3-P1 <<>> -t ns test.example.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44807
;; flags: qr rd ra; QUERY: 1, ANSWER: 4, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;test.example.com.           IN      NS

;; ANSWER SECTION:
test.example.com.    77494   IN      NS      ns-1.domain.org.
test.example.com.    77494   IN      NS      ns-2.domain.co.uk.
test.example.com.    77494   IN      NS      ns-3.domain.com.
test.example.com.    77494   IN      NS      ns-4.domain.net.

```

Given this scenario, I would expect the following assertion to pass on
both providers since the DNS records are present in both.

```rb
describe 'test.example.com' do
  it { is_expected.to have_dns.with_type("NS") }
end
```

However, that isn't the case. It will only pass on the new provider. To
make it work on the existing provider, you need to chain the
`in_authority` method onto the assertion. Like so:

```rb
describe 'test.example.com' do
  it { is_expected.to have_dns.with_type("NS").in_authority }
end
```

Doing this then breaks the test on the new provider (since it isn't an
authoritative).

This doesn't seem correct since both providers have the records and do
respond to these queries using an external tool like `dig` without the
need to recurse or query the authoritative.

To rectify the incorrect behaviour I have added an additional condition
to the method that determines which section of the DNS response to use,
that will still use the authoritive records even if the `in_authority`
method is not included in the assertion.